### PR TITLE
slick-repository-monad project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,3 +42,8 @@ lazy val `slick-repository-postgres` = project.
   settings(publishSettings).
   settings(libraryDependencies ++= Seq(postgresql) ++ Seq(slickHikari, scalaTest) ++ logging).
   dependsOn(`slick-repository-core`)
+
+lazy val `slick-repository-monad` = project.
+  settings(commonSettings).
+  settings(publishSettings).
+  settings(libraryDependencies ++= Seq(slick, scalaTest) ++ logging)

--- a/slick-repository-monad/src/main/scala/com/github/imliar/slick/repository/XorT.scala
+++ b/slick-repository-monad/src/main/scala/com/github/imliar/slick/repository/XorT.scala
@@ -1,0 +1,58 @@
+package com.github.imliar.slick.repository
+
+import slick.dbio.{DBIOAction, Effect, NoStream}
+
+import scala.concurrent.ExecutionContext
+
+class XorT[A, B, E <: Effect](val value: DBIOAction[Either[A, B], NoStream, E]) {
+
+  def map[C](f: B => C)(implicit
+                        ec: ExecutionContext): XorT[A, C, E] = new XorT(value.map({
+    case Right(b) => Right(f(b))
+    case Left(a) => Left(a)
+  }))
+
+  def flatMap[C, F <: Effect](f: B => XorT[A, C, F])(implicit
+                                                     ec: ExecutionContext): XorT[A, C, E with F] = {
+    new XorT(value.flatMap {
+      case Right(b) => f(b).value
+      case Left(a) => DBIOAction.successful(Left(a))
+    })
+  }
+
+  def flatMapF[C, F <: Effect](f: B => DBIOAction[Either[A, C], NoStream, F])(implicit
+                                                                              ec: ExecutionContext): XorT[A, C, E with F] = {
+    new XorT(value.flatMap {
+      case Right(b) => f(b)
+      case Left(a) => DBIOAction.successful(Left(a))
+    })
+  }
+
+  def ensure(onFailure: => A)(predicate: B => Boolean)(implicit
+                                                       ec: ExecutionContext): XorT[A, B, E] = {
+    new XorT(value.map {
+      case Right(b) if predicate(b) => Right(b)
+      case _ => Left(onFailure)
+    })
+  }
+
+  def assure(onFailure: B => A)(predicate: B => Boolean)(implicit
+                                                         ec: ExecutionContext): XorT[A, B, E] = {
+    new XorT(value.map {
+      case Right(b) if predicate(b) => Right(b)
+      case Right(b) => Left(onFailure(b))
+      case Left(a) => Left(a)
+    })
+  }
+
+  def leftMap[D](f: A => D)(implicit
+                            ec: ExecutionContext): XorT[D, B, E] = new XorT(value.map {
+    case Right(b) => Right(b)
+    case Left(a) => Left(f(a))
+  })
+
+}
+
+object XorT {
+  def apply[A, B, E <: Effect](dBIOAction: DBIOAction[Either[A, B], NoStream, E]) = new XorT(dBIOAction)
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2"
+version in ThisBuild := "0.3"


### PR DESCRIPTION
Place to put functional-like structures such as `XorT`. Because we can't describe the scalaz/cats monad for `DBIOAction.flatMap` without losing `Effect`